### PR TITLE
Command line improvements

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -1,13 +1,44 @@
 #!/usr/bin/env node
 
 var fmt = require('./')
+var fs = require('fs')
+var stdin = require('stdin')
+var argv = require('minimist')(process.argv.slice(2), {
+  boolean: 'write',
+  alias: {
+    w: 'write'
+  }
+})
 
-fmt.load(function (err, files) {
-  if (err) error(err)
-  var transformed = fmt.transform(files)
-  transformed.forEach(function (t) {
-    console.log(t)
-  })
+function processFile (transformed) {
+  if (argv.write && transformed.name !== 'stdin') {
+    fs.writeFileSync(transformed.name, transformed.data)
+  } else {
+    console.log(transformed.data)
+  }
+}
+
+function getFiles (done) {
+  var args = argv._
+  if (!process.stdin.isTTY) {
+    return stdin(function (file) {
+      return done(null, [{ name: 'stdin', data: file }])
+    })
+  } else if (args.length === 0) {
+    return fmt.load(done)
+  } else {
+    return done(null, args.map(function (file) {
+      return { name: file, data: fs.readFileSync(file).toString() }
+    }))
+  }
+}
+
+getFiles(function (err, files) {
+  if (err) return error(err)
+  files.forEach(function (file) {
+    file.data = fmt.transform(file.data)
+    processFile(file)
+  });
 })
 
 function error (err) {

--- a/index.js
+++ b/index.js
@@ -12,28 +12,24 @@ var DEFAULT_IGNORE = [
   '**/bundle.js'
 ]
 
-module.exports.transform = function (files) {
-  var NAMED_FUNCTION_NOSPACE = /function(\s+)?(\w+)(\s+)?\(/ig
-  var ANON_FUNCTION_NOSPACE = /function(\s+)?\(/ig
-  var NAMED_FUNCTION_SPACE = 'function $2 ('
-  var ANON_FUNCTION_SPACE = 'function ('
-  var FUNCTION_DECLARATION = /function\s(\w+)\s\((.+)?\)(\s+)?\{/ig
-  var ANON_FUNCTION_DECLARATION = /function\s\((.+)?\)(\s+)?\{/ig
-  var CLEAN_FUNCTION_DECLARATION = 'function $1 ($2) {'
-  var CLEAN_ANON_FUNCTION_DECLARATION = 'function ($1) {'
-  var MULTI_NEWLINE = /(\r?\n)(\r?\n)/g
-  var EOL = os.EOL
-  
-  files = files.map(function(f) {
-    return f
-      .replace(NAMED_FUNCTION_NOSPACE, NAMED_FUNCTION_SPACE)
-      .replace(ANON_FUNCTION_NOSPACE, ANON_FUNCTION_SPACE)
-      .replace(FUNCTION_DECLARATION, CLEAN_FUNCTION_DECLARATION)
-      .replace(ANON_FUNCTION_DECLARATION, CLEAN_ANON_FUNCTION_DECLARATION)
-      .replace(MULTI_NEWLINE, EOL)
-  })
+var NAMED_FUNCTION_NOSPACE = /function(\s+)?(\w+)(\s+)?\(/ig
+var ANON_FUNCTION_NOSPACE = /function(\s+)?\(/ig
+var NAMED_FUNCTION_SPACE = 'function $2 ('
+var ANON_FUNCTION_SPACE = 'function ('
+var FUNCTION_DECLARATION = /function\s(\w+)\s\((.+)?\)(\s+)?\{/ig
+var ANON_FUNCTION_DECLARATION = /function\s\((.+)?\)(\s+)?\{/ig
+var CLEAN_FUNCTION_DECLARATION = 'function $1 ($2) {'
+var CLEAN_ANON_FUNCTION_DECLARATION = 'function ($1) {'
+var MULTI_NEWLINE = /(\r?\n)(\r?\n)/g
+var EOL = os.EOL
 
-  return files
+module.exports.transform = function (file) {
+  return file
+    .replace(NAMED_FUNCTION_NOSPACE, NAMED_FUNCTION_SPACE)
+    .replace(ANON_FUNCTION_NOSPACE, ANON_FUNCTION_SPACE)
+    .replace(FUNCTION_DECLARATION, CLEAN_FUNCTION_DECLARATION)
+    .replace(ANON_FUNCTION_DECLARATION, CLEAN_ANON_FUNCTION_DECLARATION)
+    .replace(MULTI_NEWLINE, EOL)
 }
 
 module.exports.load = function (opts, cb) {
@@ -70,7 +66,7 @@ module.exports.load = function (opts, cb) {
         return mm.match(file)
       })
     }).map(function (f) {
-      return fs.readFileSync(f).toString() // assume utf8
+      return { name: f, data: fs.readFileSync(f).toString() } // assume utf8
     })
     cb(null, files)
   })

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
   "dependencies": {
     "find-root": "^0.1.1",
     "glob": "^4.3.5",
-    "minimatch": "^2.0.1"
+    "minimatch": "^2.0.1",
+    "minimist": "^1.1.0",
+    "stdin": "0.0.1"
   }
 }


### PR DESCRIPTION
This brings in some feature from gofmt 

* -w to write to files
* transform stdin when detected

## Examples

```bash
$ standard-format
# still works like before

$ standard-format -w
# updates file formatting and overwrites them

$ echo "some javascript" | standard-format
# dumps standard style to stdout

$ standard-format < file.js
# dumps standard style to stdout

$ standard-format file1.js file2.js
# dump specific reformatted files to stdout

$ standard-format -w file1.js file2.js
# overwrite specific files with standard style
```

etc