### PR TITLE
Initial tests

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -38,7 +38,7 @@ getFiles(function (err, files) {
   files.forEach(function (file) {
     file.data = fmt.transform(file.data)
     processFile(file)
-  });
+  })
 })
 
 function error (err) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "./bin.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "tape test/*.js"
   },
   "repository": {
     "type": "git",
@@ -23,5 +23,15 @@
     "minimatch": "^2.0.1",
     "minimist": "^1.1.0",
     "stdin": "0.0.1"
+  },
+  "devDependencies": {
+    "concat-stream": "^1.4.7",
+    "debug": "^2.1.1",
+    "once": "^1.3.1",
+    "skip-stream": "0.0.3",
+    "split": "^0.3.3",
+    "standard": "*",
+    "stream-reduce": "^1.0.3",
+    "tape": "^3.5.0"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,27 +1,41 @@
-function() {}
-function () {}
-function  () {}
+// This file is automatically ran through standard-format
+// and checked by standard. Add test cases for the formatter by adding
+// to this file
+
+// eol semicolons
+var x = 1;
+
+// eol whitespace
+x = 2 
+
+// standard-format has nothing to say about unused vars
+// so this is here to prevent invalid test cases
+console.log (x)
+
+// sol semicolons and parens spacing
+(function() {})()
+(function () {})()
+(function  () {})()
+
+(function f() {})()
+(function f2 () {})()
+(function   fooz() {})()
+(function   foox () {})()
+(function   foos   () {})()
 
 
-function f() {}
-function f () {}
-function   foo() {}
-function   foo () {}
-function   foo   () {}
+(function(){})()
+(function (){})()
+(function () {})()
+(function ()  {})()
 
 
-function(){}
-function (){}
-function () {}
-function ()  {}
+(function(){})()
+(function foo(){})()
+(function bar() {})()
+(function quux()  {})()
 
 
-function(){}
-function foo(){}
-function foo() {}
-function foo()  {}
-
-
-function(){}
-function foo (){}
-function foo ()  {}
+(function(){})()
+(function food (){})()
+(function foot ()  {})()

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,28 @@
+var test = require('tape')
+var run = require('./standard-runner')
+var fs = require('fs')
+var join = require('path').join
+var fmt = require('../').transform
+
+test('test.js ran through formatter', function (t) {
+  var file = fs.readFileSync(join(__dirname, '../test.js')).toString()
+  var formatted = fmt(file)
+  var lines = formatted.split('\n')
+
+  run(formatted, function (err, reports) {
+    t.ok(!err, 'no runner errors')
+
+    reports.forEach(function (report) {
+      var highlight = run.highlight(lines, report)
+      t.fail(report.message)
+      var comment = '\n' +
+                    report.source + ':' +
+                    report.line + ':' +
+                    report.column + ':' +
+                    report.message + highlight
+      console.log(comment)
+    })
+
+    t.end()
+  })
+})

--- a/test/standard-runner.js
+++ b/test/standard-runner.js
@@ -1,0 +1,60 @@
+var spawn = require('child_process').spawn
+var once = require('once')
+var split = require('split')
+var skip = require('skip-stream')
+var reduce = require('stream-reduce')
+var debug = require('debug')('standard-runner')
+
+function parse (line) {
+  debug('parsing line %s', line)
+  var matched = line.match(/\s*([^:]+):(\d+):(\d+):\s*(.*)/)
+  return {
+    source: matched[1],
+    line: matched[2],
+    column: matched[3],
+    message: matched[4]
+  }
+}
+
+function highlightLine (line, issue) {
+  var str = '\n'
+  str += line
+  str += '\n'
+  for (var i = 1; i <= issue.column; ++i) {
+    str += i < issue.column ? ' ' : '^'
+  }
+  return str
+}
+
+function highlight (lines, issue) {
+  return highlightLine(lines[issue.line - 1], issue)
+}
+
+function check (data, done) {
+  var standard = spawn('standard')
+  var finish = once(done)
+
+  standard.on('error', finish)
+
+  standard.stderr
+  .pipe(split())
+  .pipe(skip(1))
+  .pipe(reduce(function (acc, line) {
+    if (line)
+      acc.push(parse(line))
+    return acc
+  }, []))
+  .on('data', function(reports) {
+    debug('reports %j', reports)
+    finish(null, reports)
+  })
+
+  standard.stderr.on('end', function () {
+    finish(null)
+  })
+
+  standard.stdin.end(data)
+}
+
+module.exports = check
+module.exports.highlight = highlight


### PR DESCRIPTION
This adds a test that runs the `test.js` file through `standard-format` and then through `standard`. Any errors reported by `standard` are reported as test failures.