### PR TITLE
more standardizing

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ var EOL_SEMICOLON = /;\r?\n/g
 var SOL_SEMICOLON = /((?:\r?\n|^)[\t ]*)(\(|\[)/g
 var EOL = os.EOL
 var EOL_WHITESPACE = /[\t ]+\r?\n/g
-var SOL_SEMICOLON_BRACE = "$1;$2"
+var SOL_SEMICOLON_BRACE = '$1;$2'
 
 module.exports.transform = function (file) {
   return file

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": "./bin.js",
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "standard && tape test/*.js"
   },
   "repository": {
     "type": "git",
@@ -33,5 +33,8 @@
     "standard": "*",
     "stream-reduce": "^1.0.3",
     "tape": "^3.5.0"
+  },
+  "standard": {
+    "ignore":"test.js"
   }
 }

--- a/test/whitespace.js
+++ b/test/whitespace.js
@@ -1,16 +1,15 @@
-
 var test = require('tape')
 var fmt = require('../').transform
 
 test('sol whitespace', function (t) {
   t.plan(2)
 
-  var program  = '   [1,2,3].map'
+  var program = '   [1,2,3].map'
   var expected = '   ;[1,2,3].map'
   var msg = 'first line sol whitespace is preserved during semicolon insertion'
   t.equal(fmt(program), expected, msg)
 
-  program  = '\n\t\t[1,2,3].map'
+  program = '\n\t\t[1,2,3].map'
   expected = '\n\t\t;[1,2,3].map'
   msg = 'newline sol tabs are preserved during semicolon insertion'
   t.equal(fmt(program), expected, msg)


### PR DESCRIPTION
call standard as part of npm test
add "test.js" to standard.ignore in package.json
fix a few standard lint issues
