### PR TITLE
format comments with whitespace after //

### DIFF
--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -305,7 +305,8 @@
   "plugins": [
     "esformatter-quotes",
     "esformatter-literal-notation",
-    "esformatter-eol-last"
+    "esformatter-eol-last",
+    "esformatter-spaced-lined-comment"
   ],
 
   "quotes": {

--- a/test.js
+++ b/test.js
@@ -18,6 +18,7 @@ console.log(x)
 (function () {})()
 (function  () {})()
 
+//bad comment -- needs a space after slashes
 var test = "what";
 
 if (true) {

--- a/test/comments.js
+++ b/test/comments.js
@@ -1,0 +1,11 @@
+var test = require('tape')
+var fmt = require('../').transform
+
+test('comments formatting', function (t) {
+  t.plan(1)
+
+  var program = '//bad comment\n'
+  var expected = '// bad comment\n'
+  var msg = 'Expect space or tab after // in comment'
+  t.equal(fmt(program), expected, msg)
+})


### PR DESCRIPTION
Formats comments to adhere to:
```
Expected space or tab after // in comment. (eslint/spaced-line-comment)
```