### PR TITLE
Allow for single line if expression assignments

### DIFF
--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -74,8 +74,8 @@
       "ElseStatementOpeningBrace" : 0,
       "ElseStatementClosingBrace" : ">=1",
       "LogicalExpression" : -1,
-      "ObjectExpressionClosingBrace" : ">=1",
-      "Property" : ">=1",
+      "ObjectExpressionClosingBrace" : ">=0",
+      "Property" : ">=0",
       "ReturnStatement" : -1,
       "SwitchOpeningBrace" : 0,
       "SwitchClosingBrace" : ">=1",
@@ -136,8 +136,9 @@
       "ElseStatementOpeningBrace" : ">=1",
       "ElseStatementClosingBrace" : ">=1",
       "LogicalExpression" : -1,
-      "ObjectExpressionOpeningBrace" : ">=1",
+      "ObjectExpressionOpeningBrace" : ">=0",
       "Property" : 0,
+      "PropertyValue" : ">=0",
       "ReturnStatement" : -1,
       "SwitchOpeningBrace" : ">=1",
       "SwitchClosingBrace" : ">=1",
@@ -226,7 +227,8 @@
       "WhileStatementConditionalOpening" : 1,
       "WhileStatementConditionalClosing" : 0,
       "WhileStatementOpeningBrace" : 1,
-      "WhileStatementClosingBrace" : 1
+      "WhileStatementClosingBrace" : 1,
+      "ObjectExpressionClosingBrace": 1
     },
 
     "after" : {

--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -31,7 +31,7 @@
     "value" : "\n",
 
     "before" : {
-      "AssignmentExpression" : ">=1",
+      "AssignmentExpression" : ">=0",
       "AssignmentOperator": 0,
       "BlockStatement" : 0,
       "CallExpression" : -1,

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -1,11 +1,18 @@
 var test = require('tape')
 var fmt = require('../').transform
 
-test('singleline ', function (t) {
-  t.plan(1)
-  var program = 'if (!opts) opts = {}'
+var noops = [
+  { str: 'if (!opts) opts = {}\n',
+    msg: 'noop on single line conditional assignment' },
 
-  var expected = 'if (!opts) opts = {}\n'
+  { str: 'var g = { name: f, data: fs.readFileSync(f).toString() }\n',
+    msg: 'noop on single line object assignment'
+  }
+]
 
-  t.equal(fmt(program), expected)
+test('singleline noop expressions', function (t) {
+  t.plan(noops.length)
+  noops.forEach(function (obj) {
+    t.equal(fmt(obj.str), obj.str, obj.msg)
+  })
 })

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -1,0 +1,11 @@
+var test = require('tape')
+var fmt = require('../').transform
+
+test('singleline ', function (t) {
+  t.plan(1)
+  var program = 'if (!opts) opts = {}'
+
+  var expected = 'if (!opts) opts = {}\n'
+
+  t.equal(fmt(program), expected)
+})


### PR DESCRIPTION
Running standard-format over the standard-format codebase, I noticed quite a few overly aggressive auto-formats, especially with regards to single line expressions.  Since `standard` does not specify behavior here, neither should the formatter.  There are quite a few others formatting rules that need to calm down to accommodate this e.g: 

line 74 in index.js
```js
return { name: f, data: fs.readFileSync(f).toString() } // assume utf
```
is turned into: 

```js
return {
          name: f,
          data: fs.readFileSync(f).toString()
        } // assume utf8
```