### PR TITLE
Added tests capturing recent issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "tape": "^3.5.0"
   },
   "standard": {
-    "ignore": ["test.js","**test/failing/**"]
+    "ignore": ["test.js", "**test/failing/**"]
   }
 }

--- a/test.js
+++ b/test.js
@@ -36,7 +36,7 @@ function   fooz() {}
 function   foox () {}
 function   foos   () {}
 
-var x = function() {}
+var anon = function() {}
 
 f2( obj)
 f2(obj )
@@ -46,7 +46,7 @@ f2( obj,obj )
 fooz()
 foox()
 foos()
-x(another)
+anon(another)
 
 function foo(){}
 function bar() {}

--- a/test.js
+++ b/test.js
@@ -25,6 +25,7 @@ if (test) {
 }
 
 var obj = {val: 2}
+var another = { foo: 'bar' }
 
 // space after function name and arg paren
 ;[1].forEach(function(){})
@@ -35,6 +36,8 @@ function   fooz() {}
 function   foox () {}
 function   foos   () {}
 
+var x = function() {}
+
 f2( obj)
 f2(obj )
 f2( obj )
@@ -43,6 +46,7 @@ f2( obj,obj )
 fooz()
 foox()
 foos()
+x(another)
 
 function foo(){}
 function bar() {}

--- a/test/failing/multiline.js
+++ b/test/failing/multiline.js
@@ -1,0 +1,21 @@
+var test = require('tape')
+var fmt = require('../../').transform
+
+var noops = [
+  {
+    program:
+    'var cool =\n' +
+    '  a +\n' +
+    '  b +\n' +
+    '  c\n',
+
+    msg: 'allow newlines after assignment operator'
+  }
+]
+
+test('multiline noop', function (t) {
+  t.plan(noops.length)
+  noops.forEach(function (obj) {
+    t.equal(fmt(obj.program), obj.program, obj.msg)
+  })
+})

--- a/test/multiline.js
+++ b/test/multiline.js
@@ -75,6 +75,16 @@ var noops = [
 
     msg: 'Dont mess with function tabbing'
 
+  },
+  {
+    program:
+    'var obj = {\n' +
+    "  'standard': {\n" +
+    "    'ignore': ['test.js', '**test/failing/**']\n" +
+    '  }\n' +
+    '}\n',
+
+    msg: 'allow single line object arrays'
   }
 ]
 

--- a/test/multiline.js
+++ b/test/multiline.js
@@ -1,37 +1,86 @@
 var test = require('tape')
 var fmt = require('../').transform
 
-test('multiline ', function (t) {
-  t.plan(3)
-
-  var program =
+var collapse = [
+  {
+    program:
     'var x = 1\n' +
     '\n' +
     '\n' +
-    'var z = 2\n'
+    'var z = 2\n',
 
-  var expected =
+    expected:
     'var x = 1\n' +
     '\n' +
-    'var z = 2\n'
+    'var z = 2\n',
 
-  var msg = 'two empty lines should collapse to one'
-  t.equal(fmt(program), expected, msg)
-
-  program =
+    msg: 'two empty lines should collapse to one'
+  },
+  {
+    program:
     'var x = 1\n' +
     '\n' + '\n' + '\n' + '\n' + '\n' +
     '\n' + '\n' + '\n' + '\n' + '\n' +
-    'var z = 2\n'
+    'var z = 2\n',
 
-  msg = 'ten empty lines should collapse to one'
-  t.equal(fmt(program), expected, msg)
-
-  program =
+    expected:
     'var x = 1\n' +
     '\n' +
-    'var z = 2\n'
+    'var z = 2\n',
 
-  msg = 'single empty line should be unmodified'
-  t.equal(fmt(program), program, msg)
+    msg: 'ten empty lines should collapse to one'
+  },
+  {
+    program:
+    'var foo = function () {\n' +
+    '\n' +
+    '  bar()\n' +
+    '}\n',
+
+    expected:
+    'var foo = function () {\n' +
+    '  bar()\n' +
+    '}\n',
+    msg: 'Remove padding newlines after curly braces'
+  }
+]
+
+test('multiline collapse', function (t) {
+  t.plan(collapse.length)
+  collapse.forEach(function (obj) {
+    t.equal(fmt(obj.program), obj.expected, obj.msg)
+  })
+})
+
+var noops = [
+  {
+    program:
+    'var x = 1\n' +
+    '\n' +
+    'var z = 2\n',
+
+    msg: 'single empty line should be unmodified'
+  },
+  {
+    program:
+    'function getRequests (cb) {\n' +
+    '  nets({\n' +
+    "    url: binUrl + '/api/v1/bins/' + bin.name + '/requests',\n" +
+    '    json: true,\n' +
+    '    headers: headers\n' +
+    '  }, function (err, resp, body) {\n' +
+    '    cb(err, resp, body)\n' +
+    '  })\n' +
+    '}\n',
+
+    msg: 'Dont mess with function tabbing'
+
+  }
+]
+
+test('multiline noop', function (t) {
+  t.plan(noops.length)
+  noops.forEach(function (obj) {
+    t.equal(fmt(obj.program), obj.program, obj.msg)
+  })
 })

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -11,6 +11,9 @@ var noops = [
   {
     str: '{foo: \'bar\'}\n',
     msg: 'Dont add padding to object braces'
+  },
+  { str: "var x = ['test.js', '**test/failing/**']\n",
+    msg: 'Noop on singleline arrays'
   }
 ]
 

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -7,6 +7,10 @@ var noops = [
 
   { str: 'var g = { name: f, data: fs.readFileSync(f).toString() }\n',
     msg: 'noop on single line object assignment'
+  },
+  {
+    str: '{foo: \'bar\'}\n',
+    msg: 'Dont add padding to object braces'
   }
 ]
 
@@ -14,5 +18,20 @@ test('singleline noop expressions', function (t) {
   t.plan(noops.length)
   noops.forEach(function (obj) {
     t.equal(fmt(obj.str), obj.str, obj.msg)
+  })
+})
+
+var transforms = [
+  {
+    str: 'var x = function() {}\n',
+    expect: 'var x = function () {}\n',
+    msg: 'Anonomous function spacing between keyword and arguments'
+  }
+]
+
+test('singleline transforms', function (t) {
+  t.plan(transforms.length)
+  transforms.forEach(function (obj) {
+    t.equal(fmt(obj.str), obj.expect, obj.msg)
   })
 })


### PR DESCRIPTION
https://github.com/maxogden/standard-format/issues/28
https://github.com/maxogden/standard-format/issues/24
https://github.com/maxogden/standard-format/issues/23
https://github.com/maxogden/standard-format/issues/20

Also adds a failing test regarding white space after the assignment operator with a new line:

```js
operator: equal
expected: 'var cool =\n  a +\n  b +\n  c\n'
actual:   'var cool =\na +\n  b +\n  c\n'
```