### PR TITLE
Ensure single space after variable name

### DIFF
--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -245,7 +245,7 @@
       "TryOpeningBrace" : -1,
       "TryClosingBrace" : -1,
       "UnaryExpressionOperator": -1,
-      "VariableName" : -1,
+      "VariableName" : 1,
       "WhileStatementConditionalOpening" : -1,
       "WhileStatementConditionalClosing" : -1,
       "WhileStatementOpeningBrace" : -1,

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -36,6 +36,11 @@ var transforms = [
     msg: 'Squash spaces around variable value'
   },
   {
+    str: 'var hi           = 1\n',
+    expect: 'var hi = 1\n',
+    msg: 'Space after variable name'
+  },
+  {
     str: 'var hi\n hi =    1\n',
     expect: 'var hi\nhi = 1\n',
     msg: 'Squash spaces around assignment operator'


### PR DESCRIPTION
This formats to match the standard eslint rule [no-multi-spaces](http://eslint.org/docs/rules/no-multi-spaces.html)