### PR TITLE
Avoid mangling functions containing the word ‘function’

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var DEFAULT_IGNORE = [
   '**/bundle.js'
 ]
 
-var NAMED_FUNCTION_NOSPACE = /function([ \t]+)?(\w+)(\s+)?\(/ig
+var NAMED_FUNCTION_NOSPACE = /\bfunction\b([ \t]+)?(\w+)(\s+)?\(/ig
 var NAMED_FUNCTION_SPACE = 'function $2 ('
 var MULTI_NEWLINE = /((?:\r?\n){3,})/g
 var EOL_SEMICOLON = /;\r?\n/g

--- a/test/functions.js
+++ b/test/functions.js
@@ -1,0 +1,25 @@
+var test = require('tape')
+var fmt = require('../').transform
+
+test('function formatting', function (t) {
+  t.plan(4)
+  var program = 'function x(y){}\n'
+  var expected = 'function x (y) {}\n'
+  var msg = 'Expect space around named function parentheses'
+  t.equal(fmt(program), expected, msg)
+  
+  program = 'window.x = function(y){}\n'
+  expected = 'window.x = function (y) {}\n'
+  msg = 'Expect space around anonymous function parentheses'
+  t.equal(fmt(program), expected, msg)
+
+  program = 'function x () {}\n'
+  expected = 'function x () {}\n'
+  msg = 'Expect good functions to be unchanged'
+  t.equal(fmt(program), expected, msg)
+  
+  program = "window.wrapFunctionsUntil(1)\n"
+  expected = "window.wrapFunctionsUntil(1)\n"
+  msg = 'Expect non-function-declarations to be unchanged'
+  t.equal(fmt(program), expected, msg)
+})


### PR DESCRIPTION
Hi there - I ran into a problem where standard-format would convert a function call like  - 

```javascript
utils.wrapFunctionUntilEvent(foo, bar)
```

into : 

```javascript
utils.wrapfunction UntilEvent (foo, bar)
```

How about the attached fix?