### PR TITLE
avoid touching line endings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var path = require('path')
 var fs = require('fs')
-var os = require('os')
 var glob = require('glob')
 var findRoot = require('find-root')
 var Minimatch = require('minimatch').Minimatch
@@ -14,18 +13,20 @@ var DEFAULT_IGNORE = [
   '**/bundle.js'
 ]
 
-var MULTI_NEWLINE = /((?:\r?\n){3,})/g
-var EOL_SEMICOLON = /;\r?\n/g
+var MULTI_NEWLINE_N = /((?:\n){3,})/g
+var MULTI_NEWLINE_RN = /((?:\r\n){3,})/g
+
+var EOL_SEMICOLON = /;(?=\r?\n)/g
 var EOL_SEMICOLON_WITH_COMMENT = /;(?=\s*\/\/[\s\w]*\r?\n)/g
 var SOF_NEWLINES = /^(\r?\n)+/g
-var EOL = os.EOL
 
 module.exports.transform = function (file) {
   file = file
-    .replace(MULTI_NEWLINE, EOL + EOL)
+    .replace(MULTI_NEWLINE_N, '\n\n')
+    .replace(MULTI_NEWLINE_RN, '\r\n\r\n')
 
   var formatted = formatter.format(file, ESFORMATTER_CONFIG)
-    .replace(EOL_SEMICOLON, EOL)
+    .replace(EOL_SEMICOLON, '')
     .replace(EOL_SEMICOLON_WITH_COMMENT, '')
     .replace(SOF_NEWLINES, '')
 

--- a/test/multiline.js
+++ b/test/multiline.js
@@ -1,6 +1,9 @@
 var test = require('tape')
 var fmt = require('../').transform
 
+var cr = new RegExp(/\n/g)
+var crlf = '\r\n'
+
 var collapse = [
   {
     program:
@@ -52,6 +55,15 @@ test('multiline collapse', function (t) {
   })
 })
 
+test('multiline collapse CRLF', function (t) {
+  t.plan(collapse.length)
+  collapse.forEach(function (obj) {
+    obj.program = obj.program.replace(cr, crlf)
+    obj.expected = obj.expected.replace(cr, crlf)
+    t.equal(fmt(obj.program), obj.expected, obj.msg)
+  })
+})
+
 var noops = [
   {
     program:
@@ -91,6 +103,14 @@ var noops = [
 test('multiline noop', function (t) {
   t.plan(noops.length)
   noops.forEach(function (obj) {
+    t.equal(fmt(obj.program), obj.program, obj.msg)
+  })
+})
+
+test('multiline noop CRLF', function (t) {
+  t.plan(noops.length)
+  noops.forEach(function (obj) {
+    obj.program = obj.program.replace(cr, crlf)
     t.equal(fmt(obj.program), obj.program, obj.msg)
   })
 })

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -109,3 +109,15 @@ test('singleline transforms', function (t) {
     t.equal(fmt(obj.str), obj.expect, obj.msg)
   })
 })
+
+var cr = new RegExp(/\n/g)
+var crlf = '\r\n'
+
+test('singleline transforms CRLF', function (t) {
+  t.plan(transforms.length)
+  transforms.forEach(function (obj) {
+    obj.str = obj.str.replace(cr, crlf)
+    obj.expect = obj.expect.replace(cr, crlf)
+    t.equal(fmt(obj.str), obj.expect, obj.msg)
+  })
+})


### PR DESCRIPTION
This PR updates all the regex to use positive lookahead to avoid replacing the line endings with `os.EOF`. This is because some projects may not be using the same line endings as the OS standard For example: folks on Windows may be using git's [autocrlf feature](https://help.github.com/articles/dealing-with-line-endings/) to convert endings.

This PR should fix this too: in bcomnes/sublime-standard-format#15