### PR TITLE
add v alias for version

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -7,7 +7,8 @@ var argv = require('minimist')(process.argv.slice(2), {
   boolean: ['help', 'stdin', 'version', 'write'],
   alias: {
     h: 'help',
-    w: 'write'
+    w: 'write',
+    v: 'version'
   }
 })
 
@@ -32,7 +33,7 @@ if (argv.help) {
       node_modules/, .git/, *.min.js, bundle.js
 
   Flags:
-          --version   Show current version.
+      -v  --version   Show current version.
       -w  --write     Directly modify input files.
       -h, --help      Show usage information.
 


### PR DESCRIPTION
`--write` and `--help` have alias, `version` was looking lonely. Also I had originally forked the project to add a version flag because I thought it wasn't there when I typed `standard-format -v` :astonished: 