### PR TITLE
use deglob to gather files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,15 +20,13 @@
   },
   "homepage": "https://github.com/maxogden/standard-format",
   "dependencies": {
+    "deglob": "^1.0.0",
     "esformatter": "^0.7.0",
     "esformatter-eol-last": "^1.0.0",
     "esformatter-literal-notation": "^1.0.0",
     "esformatter-quotes": "^1.0.0",
     "esformatter-semicolon-first": "^1.0.1",
     "esformatter-spaced-lined-comment": "^2.0.0",
-    "find-root": "^0.1.1",
-    "glob": "^5.0.5",
-    "minimatch": "^2.0.1",
     "minimist": "^1.1.0",
     "stdin": "0.0.1"
   },


### PR DESCRIPTION
We've refactored `standard` to extract the logic for gathering files. The result is `deglob`, which respects `.gitignore` and allows for ignoring via `package.json`.

This PR switches `standard-format` to use `deglob` when loading files. This will ensure the ignore rules apply exactly the same as `standard`.

This should also close #73 from @yoshuawuyts
