### PR TITLE
Add failing test for spaces before commas in object destructuring assignment

### DIFF
--- a/test/failing/singleline.js
+++ b/test/failing/singleline.js
@@ -7,6 +7,12 @@ var transforms = [
     expect: 'var x = {key: 123, more: 456}\n',
     msg: 'Space after comma in keys',
     issue: 'https://github.com/maxogden/standard-format/issues/54'
+  },
+  {
+    str: 'const { message, rollup, line, col, type } = origMessage\n',
+    expect: 'const { message, rollup, line, col, type } = origMessage\n',
+    msg: 'No space before comma in keys in destructuring assignment',
+    issue: 'https://github.com/maxogden/standard-format/pull/85'
   }
 ]
 


### PR DESCRIPTION
`const { message, rollup, line, col, type } = origMessage` is converted into `const { message , rollup , line , col , type } = origMessage` (adds spaces before commas).

Unsure if you want the test, but w/e :smile: 