### PR TITLE
Test for detect continuation ident bug after do-while

### DIFF
--- a/test/continuation-indent.js
+++ b/test/continuation-indent.js
@@ -1,0 +1,31 @@
+var test = require('tape')
+var fmt = require('../').transform
+
+var continuation_indent = [
+  {
+    program: ['function x()',
+      '{',
+      '  var i=0;',
+      '  do {',
+      '    i++',
+      '  } while(i<10)',
+      '  console.log(i);',
+      '}'].join('\n'),
+    expected: ['function x()',
+      '{',
+      '  var i=0;',
+      '  do {',
+      '    i++',
+      '  } while(i<10)',
+      '  console.log(i);',
+      '}'].join('\n'),
+    msg: 'do-while'
+  }
+]
+
+test('Continuation Indent', function (t) {
+  t.plan(continuation_indent.length)
+  continuation_indent.forEach(function (obj) {
+    t.equal(fmt(obj.program), obj.expected, obj.msg)
+  })
+})

--- a/test/continuation-indent.js
+++ b/test/continuation-indent.js
@@ -11,14 +11,13 @@ var continuation_indent = [
       '  } while(i<10)',
       '  console.log(i);',
       '}'].join('\n'),
-    expected: ['function x()',
-      '{',
-      '  var i=0;',
+    expected: ['function x () {',
+      '  var i = 0',
       '  do {',
       '    i++',
-      '  } while(i<10)',
-      '  console.log(i);',
-      '}'].join('\n'),
+      '  } while (i < 10)',
+      '  console.log(i)',
+      '}', ''].join('\n'),
     msg: 'do-while'
   }
 ]


### PR DESCRIPTION
## THIS PR HAS ONLY THE TEST NOT THE SOLUTION 

expected without the bug:
```javascript
function x()
{
  var i=0
  do {
    i++
  } while(i<10)
  console.log(i)
}
```
bug last do lines has wrong indent
```javascript
function x()
{
  var i=0
  do {
    i++
  } while(i<10)
    console.log(i)
  }
```
