### PR TITLE
fix member accessors

### DIFF
--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -114,7 +114,7 @@
       "ElseStatementOpeningBrace" : "<=1",
       "ElseStatementClosingBrace" : -1,
       "LogicalExpression" : -1,
-      "MemberExpressionClosing" : 1,
+      "MemberExpressionClosing" : ">=0",
       "ObjectExpressionOpeningBrace" : "<=1",
       "Property" : -1,
       "PropertyValue" : -1,

--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -114,6 +114,7 @@
       "ElseStatementOpeningBrace" : "<=1",
       "ElseStatementClosingBrace" : -1,
       "LogicalExpression" : -1,
+      "MemberExpressionClosing" : 1,
       "ObjectExpressionOpeningBrace" : "<=1",
       "Property" : -1,
       "PropertyValue" : -1,

--- a/test.js
+++ b/test.js
@@ -164,3 +164,8 @@ void {
 var gloopy = 12
 [1,2,3].map(function () {})
 console.log(gloopy)
+
+// Test member accessors
+var array = [1,2,3]
+var val = array[0]
+var val2 = array[1]

--- a/test/member.js
+++ b/test/member.js
@@ -1,0 +1,18 @@
+var test = require('tape')
+var fmt = require('../').transform
+
+test('allow newline after member accessor', function (t) {
+  t.plan(1)
+
+  var program = 'test[0]\ntest\n'
+  var expected = 'test[0]\ntest\n'
+  t.equal(fmt(program), expected)
+})
+
+test('don\'t force newline on mid-expression member accessor', function (t) {
+  t.plan(1)
+
+  var program = 'test(test[0])\n'
+  var expected = 'test(test[0])\n'
+  t.equal(fmt(program), expected)
+})


### PR DESCRIPTION
As reported in #72

Running on the following file produces an esprima parse error:

```js
test[0]
fail
```

This is because there is no handler for `MemberExpressionClosing` and it is getting converted to:

```js
test[0]fail
```

This PR adds a test for this case and rule for adding a newline after `MemberExpressionClosing`.