### PR TITLE
Update JSX and Testing Deps and disabled JSX formatting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "deglob": "^1.0.0",
     "esformatter": "^0.7.3",
     "esformatter-eol-last": "^1.0.0",
-    "esformatter-jsx": "^1.3.0",
+    "esformatter-jsx": "^2.0.11",
     "esformatter-literal-notation": "^1.0.0",
     "esformatter-quotes": "^1.0.0",
     "esformatter-semicolon-first": "^1.1.0",
@@ -39,8 +39,8 @@
     "split": "^1.0.0",
     "standard": "*",
     "stream-reduce": "^1.0.3",
-    "tap-spec": "^2.2.2",
-    "tape": "^3.5.0"
+    "tap-spec": "^4.1.0",
+    "tape": "^4.2.0"
   },
   "standard": {
     "ignore": [

--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -267,6 +267,7 @@
   },
 
   "jsx": {
+    "formatJSX": false,
     "attrsOnSameLineAsTag": false,
     "maxAttrsOnTag": 2
   },


### PR DESCRIPTION
Our JSX noop failed after the update, so I told JSX to stop doing stuff to the JSX.  I dont use JSX, so anyone feel free to chime in.

esformatter-jsx ^1.3.0 -> ^2.0.11
tap-spec -> 4.1.0
tape -> 4.2.0