### PR TITLE
switch to less dynamic way of including rc for better browserify support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-var path = require('path')
 var deglob = require('deglob')
 var fs = require('fs')
 var formatter = require('esformatter')
 
-var ESFORMATTER_CONFIG = require(path.join(__dirname, 'rc', 'esformatter.json'))
+var ESFORMATTER_CONFIG = require('./rc/esformatter.json')
 var DEFAULT_IGNORE = [
   'node_modules/**',
   '.git/**',


### PR DESCRIPTION
I'm currently building a neat little tool to lint using standard via the web, and I wanted to also include support to format.

Switching this line to include the esformatter config file in a more static way enables this package to go through browserify more easily.