### PR TITLE
update esformatter to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "homepage": "https://github.com/maxogden/standard-format",
   "dependencies": {
     "deglob": "^1.0.0",
-    "esformatter": "^0.7.3",
+    "esformatter": "^0.8.1",
     "esformatter-eol-last": "^1.0.0",
     "esformatter-jsx": "^2.0.11",
     "esformatter-literal-notation": "^1.0.0",


### PR DESCRIPTION
A newer version of esformatter has been released. (https://github.com/millermedeiros/esformatter/blob/master/CHANGELOG.md#v081-2015-10-28)

I want to get https://github.com/millermedeiros/esformatter/pull/375 in so that it cleans up the warning on https://www.bithound.io/github/maxogden/standard-format.