### PR TITLE
FunctionGeneratorAsterisk fix

### DIFF
--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -291,7 +291,7 @@
       "FunctionDeclarationClosingBrace" : -1,
       "FunctionExpressionOpeningBrace" : 1,
       "FunctionExpressionClosingBrace" : -1,
-      "FunctionGeneratorAsterisk": 0,
+      "FunctionGeneratorAsterisk": 1,
       "FunctionName" : 1,
       "IIFEClosingParentheses" : 0,
       "IfStatementConditionalOpening" : 1,


### PR DESCRIPTION
By default standart(eslint) will warn: `Missing space before *. (generator-star-spacing)`