### PR TITLE
Fix consistency with `standard`

### DIFF
--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -291,7 +291,7 @@
       "FunctionDeclarationClosingBrace" : -1,
       "FunctionExpressionOpeningBrace" : 1,
       "FunctionExpressionClosingBrace" : -1,
-      "FunctionGeneratorAsterisk": 0,
+      "FunctionGeneratorAsterisk": 1,
       "FunctionName" : 1,
       "IIFEClosingParentheses" : 0,
       "IfStatementConditionalOpening" : 1,

--- a/test/singleline.js
+++ b/test/singleline.js
@@ -32,7 +32,7 @@ var noops = [
     msg: 'Noop ES2015 import'
   },
   {
-    str: 'function* blarg (foo) {yield foo}\n',
+    str: 'function * blarg (foo) {yield foo}\n',
     msg: 'Noop ES2015 generator'
   },
   {


### PR DESCRIPTION
`standard` warn about missing space before * in generators. (generator-star-spacing)