### PR TITLE
Added esformatter-remove-trailing-commas

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "esformatter-jsx": "^3.0.0",
     "esformatter-literal-notation": "^1.0.0",
     "esformatter-quotes": "^1.0.0",
+    "esformatter-remove-trailing-commas": "^1.0.1",
     "esformatter-semicolon-first": "^1.1.0",
     "esformatter-spaced-lined-comment": "^2.0.0",
     "minimist": "^1.1.0",

--- a/rc/esformatter.json
+++ b/rc/esformatter.json
@@ -448,6 +448,7 @@
   "plugins": [
     "esformatter-quotes",
     "esformatter-literal-notation",
+    "esformatter-remove-trailing-commas",
     "esformatter-semicolon-first",
     "esformatter-spaced-lined-comment",
     "esformatter-jsx"


### PR DESCRIPTION
Added [esformatter-remove-trailing-commas](https://github.com/kewah/esformatter-remove-trailing-commas), a plugin for remove the trailing commas on arrays and objects.
#152 