### PR TITLE
Use object shorthand for properties

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports.load = function (opts, cb) {
   if (opts.ignore) ignore = ignore.concat(opts.ignore)
 
   var deglobOpts = {
-    ignore: ignore,
+    ignore,
     cwd: opts.cwd || process.cwd(),
     useGitIgnore: true,
     usePackageJson: true,


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️ 

ref: https://github.com/standard/eslint-config-standard/pull/166